### PR TITLE
Show alert after shortcut completes

### DIFF
--- a/MEAL AI/Sources/App/MEALAIApp.swift
+++ b/MEAL AI/Sources/App/MEALAIApp.swift
@@ -3,6 +3,9 @@ import SwiftUI
 
 @main
 struct MEALAIApp: App {
+    @State private var showShortcutAlert = false
+    @State private var shortcutMessage = ""
+
     var body: some Scene {
         WindowGroup {
             TabView {
@@ -12,6 +15,22 @@ struct MEALAIApp: App {
                     .tabItem { Label("Suosikit", systemImage: "star") }
                 NavigationStack { SettingsView() }
                     .tabItem { Label("Asetukset", systemImage: "gearshape") }
+            }
+            .onOpenURL { url in
+                guard url.scheme == "mealai" else { return }
+                switch url.host {
+                case "done":
+                    shortcutMessage = "Ravintoarvojen siirto onnistui"
+                    showShortcutAlert = true
+                case "error":
+                    shortcutMessage = "Shortcuttin suoritus epäonnistui"
+                    showShortcutAlert = true
+                default:
+                    break
+                }
+            }
+            .alert(shortcutMessage, isPresented: $showShortcutAlert) {
+                Button("OK", role: .cancel) { }
             }
         }
     }


### PR DESCRIPTION
## Summary
- handle custom URL callbacks from Shortcuts
- show alert informing whether shortcut transfer succeeded or failed

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e39aab988329a2c0827981e0e409