### PR TITLE
Add JSON shortcut toggle and update buttons

### DIFF
--- a/MEAL AI/Sources/Utils/ShortcutsSender.swift
+++ b/MEAL AI/Sources/Utils/ShortcutsSender.swift
@@ -8,8 +8,8 @@ enum ShortcutsSender {
 
         let defaults = UserDefaults.standard
         let name = defaults.shortcutName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let sendJSON = defaults.shortcutSendJSON
-        guard !name.isEmpty else { return }
+        let enabled = defaults.shortcutEnabled
+        guard !name.isEmpty, enabled else { return }
 
         var comps = URLComponents()
         comps.scheme = "shortcuts"
@@ -24,18 +24,11 @@ enum ShortcutsSender {
 
         // IMPORTANT: For Shortcuts URL scheme, you must provide BOTH:
         // input=text  and  text=<payload>
-        if sendJSON {
-            let payload: [String: Any] = ["carbs": c, "fat": f, "protein": p]
-            if let data = try? JSONSerialization.data(withJSONObject: payload),
-               let json = String(data: data, encoding: .utf8) {
-                items.append(.init(name: "input", value: "text"))
-                items.append(.init(name: "text", value: json))
-            }
-        } else {
-            // Plain text fallback
-            let txt = "carbs=\(c);fat=\(f);protein=\(p)"
+        let payload: [String: Any] = ["carbs": c, "fat": f, "protein": p]
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let json = String(data: data, encoding: .utf8) {
             items.append(.init(name: "input", value: "text"))
-            items.append(.init(name: "text", value: txt))
+            items.append(.init(name: "text", value: json))
         }
 
         comps.queryItems = items

--- a/MEAL AI/Sources/Utils/UserDefaults+Settings.swift
+++ b/MEAL AI/Sources/Utils/UserDefaults+Settings.swift
@@ -48,9 +48,10 @@ extension UserDefaults {
         set { set(newValue, forKey: "shortcutName") }
     }
 
-    var shortcutSendJSON: Bool {
-        get { bool(forKey: "shortcutSendJSON") }
-        set { set(newValue, forKey: "shortcutSendJSON") }
+    /// Controls whether the app should send data to a Shortcut.
+    var shortcutEnabled: Bool {
+        get { bool(forKey: "shortcutEnabled") }
+        set { set(newValue, forKey: "shortcutEnabled") }
     }
 
     var appLanguage: String {

--- a/MEAL AI/Sources/Views/Search/ResultView.swift
+++ b/MEAL AI/Sources/Views/Search/ResultView.swift
@@ -13,6 +13,7 @@ struct ResultView: View {
     @State private var fat: Int
     @State private var showingHistoryAlert = false
     @EnvironmentObject var historyStore: HistoryStore
+    @AppStorage("shortcutEnabled") private var shortcutEnabled: Bool = true
 
     init(result: StageMealResult, image: UIImage?) {
         self.result = result
@@ -69,7 +70,12 @@ struct ResultView: View {
             }
 
             HStack {
-                Button("Tallenna ateria") {
+                Button {
+                    favName = result.mealName ?? "Suosikki"; showFavSheet = true
+                } label: { Image(systemName: "star") }
+                .buttonStyle(.bordered)
+
+                Button {
                     let resized = image?.resized(to: CGSize(width: 100, height: 100))
                     let entry = HistoryEntry(
                         name: result.mealName ?? "Ateria",
@@ -82,17 +88,13 @@ struct ResultView: View {
                     )
                     historyStore.add(entry: entry)
                     showingHistoryAlert = true
+                    if shortcutEnabled {
+                        ShortcutsSender.sendToShortcuts(stage: editedResult)
+                    }
+                } label: {
+                    Label(shortcutEnabled ? "Lähetä ja tallenna ateria" : "Tallenna ateria",
+                          systemImage: shortcutEnabled ? "bolt" : "tray.and.arrow.down")
                 }
-                .buttonStyle(.bordered)
-
-                Button {
-                    favName = result.mealName ?? "Suosikki"; showFavSheet = true
-                } label: { Label("Lisää suosikkeihin", systemImage: "star") }
-                .buttonStyle(.bordered)
-
-                Button {
-                    ShortcutsSender.sendToShortcuts(stage: editedResult)
-                } label: { Label("Lähetä iAPS (Shortcut)", systemImage: "bolt") }
                 .buttonStyle(.borderedProminent)
             }
             Spacer()

--- a/MEAL AI/Sources/Views/Settings/SettingsView.swift
+++ b/MEAL AI/Sources/Views/Settings/SettingsView.swift
@@ -14,7 +14,7 @@ struct SettingsView: View {
     @State private var usda: String = UserDefaults.standard.usdaApiKey ?? ""
 
     @AppStorage("shortcutName") private var shortcutName: String = ""
-    @AppStorage("shortcutSendJSON") private var shortcutSendJSON: Bool = true
+    @AppStorage("shortcutEnabled") private var shortcutEnabled: Bool = true
 
     @State private var testing = false
     @State private var testResult: String?
@@ -60,7 +60,7 @@ struct SettingsView: View {
 
             Section {
                 TextField("Shortcuttin nimi", text: $shortcutName)
-                Toggle("Lähetä makrot JSON-inputina", isOn: $shortcutSendJSON)
+                Toggle("Lähetä tiedot Shortcutille", isOn: $shortcutEnabled)
                 Text("Sovellus välittää Shortcutille JSON-objektin: { \"carbs\": 00, \"fat\": 00, \"protein\": 00 }.")
                     .font(.footnote).foregroundColor(.secondary)
             } header: { Text("Shortcuts") }


### PR DESCRIPTION
## Summary
- Always send macros to Shortcuts as JSON when enabled
- Replace Shortcut format toggle with enable/disable option
- Rename send button to "Lähetä ja tallenna ateria" and show star-only favorites button

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -project 'MEAL AI.xcodeproj' -scheme 'MEAL AI' test` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f7bb89a08329b33040f94631f5ac