### PR TITLE
Support multiple meal photos for AI analysis

### DIFF
--- a/MEAL AI/Sources/Services/FoodSearchRouter.swift
+++ b/MEAL AI/Sources/Services/FoodSearchRouter.swift
@@ -5,7 +5,7 @@ final class FoodSearchRouter {
     static let shared = FoodSearchRouter()
     private init() {}
 
-    enum Input { case text(String); case voice(String); case barcode(String); case image(Data) }
+    enum Input { case text(String); case voice(String); case barcode(String); case images([Data]) }
 
     func run(_ input: Input) async throws -> StageMealResult {
         switch input {
@@ -17,8 +17,8 @@ final class FoodSearchRouter {
             let off  = try await OpenFoodFactsService.shared.fetchProduct(barcode: code)
             let ai   = try await AIFoodAnalysis.shared.analyze(baseInfo: off, query: off.name)
             return map(base: off, ai: ai)
-        case .image(let data):
-            let ai = try await AIFoodAnalysis.shared.analyze(imageData: data)
+        case .images(let data):
+            let ai = try await AIFoodAnalysis.shared.analyze(imageDatas: data)
             return map(base: nil, ai: ai)
         }
     }

--- a/MEAL AI/Sources/Services/OpenAIAPI.swift
+++ b/MEAL AI/Sources/Services/OpenAIAPI.swift
@@ -20,7 +20,7 @@ final class OpenAIAPI {
         model: OpenAIModel,
         systemPrompt: String,
         userPrompt: String,
-        imageData: Data? = nil,
+        imageDatas: [Data]? = nil,
         temperature: Double = 0.0,
         maxCompletionTokens: Int = 600,
         forceJSON: Bool = true
@@ -31,12 +31,15 @@ final class OpenAIAPI {
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         var messages: [[String: Any]] = [["role": "system", "content": systemPrompt]]
-        if let imageData = imageData {
-            let base64 = imageData.base64EncodedString()
-            let textPart: [String: Any]  = ["type": "text", "text": userPrompt]
-            let imagePart: [String: Any] = ["type": "image_url",
-                                            "image_url": ["url": "data:image/jpeg;base64,\(base64)"]]
-            messages.append(["role": "user", "content": [textPart, imagePart]])
+        if let imageDatas = imageDatas, !imageDatas.isEmpty {
+            var content: [[String: Any]] = [["type": "text", "text": userPrompt]]
+            for data in imageDatas {
+                let base64 = data.base64EncodedString()
+                let part: [String: Any] = ["type": "image_url",
+                                           "image_url": ["url": "data:image/jpeg;base64,\(base64)"]]
+                content.append(part)
+            }
+            messages.append(["role": "user", "content": content])
         } else {
             messages.append(["role": "user", "content": userPrompt])
         }

--- a/MEAL AI/Sources/Views/Search/SearchView.swift
+++ b/MEAL AI/Sources/Views/Search/SearchView.swift
@@ -11,6 +11,7 @@ struct SearchView: View {
     @State private var errorMessage: String?
     @State private var result: StageMealResult?
     @State private var currentImage: UIImage?
+    @State private var currentImages: [UIImage] = []
 
     @ObservedObject private var favs = FavoritesStore.shared
 
@@ -34,6 +35,7 @@ struct SearchView: View {
                 Button {
                     showingCamera = true
                     currentImage = nil
+                    currentImages = []
                 } label: {
                     Label("Kamera", systemImage: "camera")
                 }.buttonStyle(.bordered)
@@ -71,10 +73,11 @@ struct SearchView: View {
             }
         }
         .sheet(isPresented: $showingCamera) {
-            CameraView { data in
+            CameraView { datas in
                 showingCamera = false
-                currentImage = UIImage(data: data)
-                Task { await run(.image(data)) }
+                currentImages = datas.compactMap { UIImage(data: $0) }
+                currentImage = currentImages.first
+                Task { await run(.images(datas)) }
             }
         }
         .sheet(item: $result) { r in ResultView(result: r, image: currentImage) }


### PR DESCRIPTION
## Summary
- replace CameraView with a PhotosPicker-based view supporting up to three images
- allow SearchView to capture or select multiple photos and send them to analysis
- extend routing and AI services to handle arrays of image data

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fa69b8388329bfbb3a451d01e305