### PR TITLE
Add iAPS Shortcut download link

### DIFF
--- a/MEAL AI/Sources/Views/Settings/SettingsView.swift
+++ b/MEAL AI/Sources/Views/Settings/SettingsView.swift
@@ -61,6 +61,7 @@ struct SettingsView: View {
                 Toggle("Lähetä tiedot Shortcutille", isOn: $shortcutEnabled)
                 Text("Sovellus välittää Shortcutille JSON-objektin: { \"carbs\": 00, \"fat\": 00, \"protein\": 00 }.")
                     .font(.footnote).foregroundColor(.secondary)
+                Link("Hanki iAPS Shortcut", destination: URL(string: "https://www.icloud.com/shortcuts/46175787d9af4d0ebfc505f3d7129043")!)
             } header: { Text("Shortcuts") }
 
             Section {


### PR DESCRIPTION
## Summary
- add link in Settings to fetch iAPS Shortcut

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme "MEAL AI" -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b30c9498a88329b186be5207598616