### PR TITLE
Make HomeView navigation path codable

### DIFF
--- a/MEAL AI/Sources/Views/Home/HomeView.swift
+++ b/MEAL AI/Sources/Views/Home/HomeView.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
 struct HomeView: View {
-    @State private var path = NavigationPath()
+    @State private var path: [Destination] = []
     @State private var query = ""
     @State private var showCamera = false
     @State private var showBarcode = false
 
-    private enum Destination: Hashable {
+    private enum Destination: Hashable, Codable {
         case search(String)
         case favorites
         case history


### PR DESCRIPTION
## Summary
- Make HomeView's navigation path use a strongly typed array
- Conform HomeView.Destination to `Hashable` and `Codable`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b31207cbb083299703be58e6fd7eb4