### PR TITLE
Fix infinite recursion in UIColor extension

### DIFF
--- a/MEAL AI/Sources/Utils/DesignSystem.swift
+++ b/MEAL AI/Sources/Utils/DesignSystem.swift
@@ -183,11 +183,3 @@ extension Color {
     })
   }
 }
-
-// UIKit-käyttöön tarvittaessa
-extension UIColor {
-  convenience init(_ color: Color) {
-    let ui = UIColor(color)
-    self.init(cgColor: ui.cgColor)
-  }
-}


### PR DESCRIPTION
## Summary
- remove custom UIColor initializer that recursively called itself

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b31e6552c083299f5216f04fd6b808