### PR TITLE
Increase spacing around tab bar camera button

### DIFF
--- a/MEAL AI/Sources/Views/Home/HomeView.swift
+++ b/MEAL AI/Sources/Views/Home/HomeView.swift
@@ -205,11 +205,11 @@ struct TabBarWithFab: View {
                     HStack {
                         IconButton("barcode.viewfinder", action: onBarcode)
                         IconButton("star", action: onFavorites)
-                        Spacer().frame(width: 72)
+                        Spacer().frame(width: 96)
                         IconButton("list.bullet.rectangle", action: onHistory)
                         IconButton("gearshape", action: onSettings)
                     }
-                    .padding(.horizontal, DS.Spacing.xl.rawValue)
+                    .padding(.horizontal, DS.Spacing.lg.rawValue)
                 )
             FabButton(action: onCamera)
                 .offset(y: -28)


### PR DESCRIPTION
## Summary
- widen tab bar spacing by expanding central spacer
- tweak horizontal padding to keep layout balanced

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b321af69c08329b649bfb2f942daa0