### PR TITLE
Use DSColor tokens in analysis overlay

### DIFF
--- a/MEAL AI/Sources/Views/Search/AnalysisOverlayView.swift
+++ b/MEAL AI/Sources/Views/Search/AnalysisOverlayView.swift
@@ -19,7 +19,7 @@ struct AnalysisOverlayView: View {
                 ForEach(steps.indices, id: \.self) { idx in
                     HStack {
                         Image(systemName: idx < step ? "checkmark.circle.fill" : "circle")
-                            .foregroundColor(idx < step ? .green : .secondary)
+                            .foregroundStyle(idx < step ? DSColor.success : DSColor.textSecondary)
                         Text(steps[idx]).font(.footnote)
                     }
                 }


### PR DESCRIPTION
## Summary
- replace hard-coded system colors in analysis overlay with DSColor tokens

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b3234f7bec8329b50831ee8a1a52d4