### PR TITLE
Space out home tab bar icons

### DIFF
--- a/MEAL AI/Sources/Views/Home/HomeView.swift
+++ b/MEAL AI/Sources/Views/Home/HomeView.swift
@@ -204,9 +204,11 @@ struct TabBarWithFab: View {
                 .overlay(
                     HStack {
                         IconButton("barcode.viewfinder", action: onBarcode)
+                        Spacer()
                         IconButton("star", action: onFavorites)
                         Spacer().frame(width: 96)
                         IconButton("list.bullet.rectangle", action: onHistory)
+                        Spacer()
                         IconButton("gearshape", action: onSettings)
                     }
                     .padding(.horizontal, DS.Spacing.lg.rawValue)


### PR DESCRIPTION
## Summary
- Add spacing around home screen tab bar icons for a more relaxed layout

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project 'MEAL AI.xcodeproj' -scheme 'MEAL AI' -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32f0f4bbc832996a5aca2a3442524