### PR TITLE
Add App Group entitlement

### DIFF
--- a/MEAL AI.xcodeproj/project.pbxproj
+++ b/MEAL AI.xcodeproj/project.pbxproj
@@ -173,10 +173,15 @@
 				LastSwiftUpdateCheck = 1640;
 				LastUpgradeCheck = 1640;
 				TargetAttributes = {
-					F1C408382E6246D000E6DA6C = {
-						CreatedOnToolsVersion = 16.4;
-					};
-					F1C408452E6246D200E6DA6C = {
+                                       F1C408382E6246D000E6DA6C = {
+                                               CreatedOnToolsVersion = 16.4;
+                                               SystemCapabilities = {
+                                                       com.apple.ApplicationGroups.iOS = {
+                                                               enabled = 1;
+                                                       };
+                                               };
+                                       };
+                                       F1C408452E6246D200E6DA6C = {
 						CreatedOnToolsVersion = 16.4;
 						TestTargetID = F1C408382E6246D000E6DA6C;
 					};
@@ -394,9 +399,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+                               ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                               CODE_SIGN_STYLE = Automatic;
+                               CODE_SIGN_ENTITLEMENTS = "MEAL AI/MEAL AI.entitlements";
+                               CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = V2P3XJ8233;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -425,9 +431,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+                               ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                               CODE_SIGN_STYLE = Automatic;
+                               CODE_SIGN_ENTITLEMENTS = "MEAL AI/MEAL AI.entitlements";
+                               CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = V2P3XJ8233;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/MEAL AI/MEAL AI.entitlements
+++ b/MEAL AI/MEAL AI.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.lajtinen.MEAL-AI</string>
+    </array>
+</dict>
+</plist>

--- a/MEAL AI/README.md
+++ b/MEAL AI/README.md
@@ -19,3 +19,4 @@ Itsenäinen SwiftUI-sovellus nimellä **MEAL AI**. Ominaisuudet:
 ## Huom.
 - Claude/Gemini on jätetty placeholderiksi – voit lisätä provider-luokat samalla rajapinnalla.
 - Kuvien lähetys tehdään base64-data-urlina OpenAI chat completions -päätepisteelle.
+- App Group (`group.lajtinen.MEAL-AI`) on valmiina tulevia integraatioita varten.


### PR DESCRIPTION
## Summary
- add App Group entitlement file
- enable App Groups capability in project settings
- document the new App Group

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b3301421388329ba9805875f4f85b7