### PR TITLE
Process camera images and attach metadata

### DIFF
--- a/MEAL AI/Sources/Models/ImagePayload.swift
+++ b/MEAL AI/Sources/Models/ImagePayload.swift
@@ -1,0 +1,10 @@
+import Foundation
+import UIKit
+
+struct ImagePayload {
+    let data: Data
+    let luma: Double
+    let timestamp: Date
+    let angle: Double?
+}
+

--- a/MEAL AI/Sources/Services/FoodSearchRouter.swift
+++ b/MEAL AI/Sources/Services/FoodSearchRouter.swift
@@ -5,7 +5,7 @@ final class FoodSearchRouter {
     static let shared = FoodSearchRouter()
     private init() {}
 
-    enum Input { case text(String); case barcode(String); case images([Data]) }
+    enum Input { case text(String); case barcode(String); case images([ImagePayload]) }
 
     func run(_ input: Input) async throws -> StageMealResult {
         switch input {
@@ -17,8 +17,9 @@ final class FoodSearchRouter {
             let off  = try await OpenFoodFactsService.shared.fetchProduct(barcode: code)
             let ai   = try await AIFoodAnalysis.shared.analyze(baseInfo: off, query: off.name)
             return map(base: off, ai: ai)
-        case .images(let data):
-            let ai = try await AIFoodAnalysis.shared.analyze(imageDatas: data)
+        case .images(let payloads):
+            let datas = payloads.map { $0.data }
+            let ai = try await AIFoodAnalysis.shared.analyze(imageDatas: datas)
             return map(base: nil, ai: ai)
         }
     }

--- a/MEAL AI/Sources/Utils/ImageProcessor.swift
+++ b/MEAL AI/Sources/Utils/ImageProcessor.swift
@@ -1,0 +1,78 @@
+import UIKit
+import CoreImage
+
+enum ImageProcessor {
+    static func process(_ image: UIImage, angle: Double? = nil) -> ImagePayload? {
+        let oriented = image.normalizedOrientation()
+        let resized = oriented.resized(maxSide: 1024)
+        guard let data = resized.jpegDataInRange(minKB: 300, maxKB: 600) else { return nil }
+        let luma = resized.averageLuma()
+        return ImagePayload(data: data, luma: luma, timestamp: Date(), angle: angle)
+    }
+}
+
+private extension UIImage {
+    func normalizedOrientation() -> UIImage {
+        if imageOrientation == .up { return self }
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        draw(in: CGRect(origin: .zero, size: size))
+        let normalized = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return normalized ?? self
+    }
+
+    func resized(maxSide: CGFloat) -> UIImage {
+        let aspect = size.width / size.height
+        var newSize: CGSize
+        if size.width > size.height {
+            newSize = CGSize(width: maxSide, height: maxSide / aspect)
+        } else {
+            newSize = CGSize(width: maxSide * aspect, height: maxSide)
+        }
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+
+    func jpegDataInRange(minKB: Int, maxKB: Int) -> Data? {
+        var lower: CGFloat = 0.0
+        var upper: CGFloat = 1.0
+        var data: Data?
+        for _ in 0..<6 {
+            let q = (lower + upper) / 2
+            data = jpegData(compressionQuality: q)
+            guard let d = data else { return nil }
+            let kb = d.count / 1024
+            if kb > maxKB {
+                upper = q
+            } else if kb < minKB {
+                lower = q
+            } else {
+                break
+            }
+        }
+        return data
+    }
+
+    func averageLuma() -> Double {
+        guard let ciImage = CIImage(image: self) else { return 0 }
+        let context = CIContext()
+        let extent = ciImage.extent
+        let filter = CIFilter.areaAverage()
+        filter.inputImage = ciImage
+        filter.extent = extent
+        guard let output = filter.outputImage else { return 0 }
+        var bitmap = [UInt8](repeating: 0, count: 4)
+        context.render(output,
+                       toBitmap: &bitmap,
+                       rowBytes: 4,
+                       bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+                       format: .RGBA8,
+                       colorSpace: nil)
+        let r = Double(bitmap[0]) / 255.0
+        let g = Double(bitmap[1]) / 255.0
+        let b = Double(bitmap[2]) / 255.0
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b
+    }
+}

--- a/MEAL AI/Sources/Views/Camera/CameraView.swift
+++ b/MEAL AI/Sources/Views/Camera/CameraView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 import UIKit
 
 struct CameraView: UIViewControllerRepresentable {
-    var onImagesPicked: ([Data]) -> Void
+    var angle: Double? = nil
+    var onImagesPicked: ([ImagePayload]) -> Void
     @Environment(\.dismiss) private var dismiss
 
     func makeCoordinator() -> Coordinator {
@@ -30,8 +31,8 @@ struct CameraView: UIViewControllerRepresentable {
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
             defer { parent.dismiss() }
             if let image = info[.originalImage] as? UIImage,
-               let data = image.jpegData(compressionQuality: 0.8) {
-                parent.onImagesPicked([data])
+               let processed = ImageProcessor.process(image, angle: parent.angle) {
+                parent.onImagesPicked([processed])
             }
         }
 

--- a/MEAL AI/Sources/Views/Home/HomeView.swift
+++ b/MEAL AI/Sources/Views/Home/HomeView.swift
@@ -68,11 +68,11 @@ struct HomeView: View {
                 }
             }
             .sheet(isPresented: $showCamera) {
-                CameraView { datas in
+                CameraView(angle: 0) { payloads in
                     showCamera = false
-                    currentImages = datas.compactMap { UIImage(data: $0) }
+                    currentImages = payloads.compactMap { UIImage(data: $0.data) }
                     currentImage = currentImages.first
-                    Task { await run(.images(datas)) }
+                    Task { await run(.images(payloads)) }
                 }
             }
             .sheet(isPresented: $showBarcode) {


### PR DESCRIPTION
## Summary
- add ImageProcessor to normalize orientation, resize to ~1024px, compress, and compute luma
- wrap image data with timestamp and angle metadata via new ImagePayload
- thread processed images through CameraView, HomeView, and FoodSearchRouter

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3421760848329a719160d98c26243