### PR TITLE
Add camera picker with gallery option

### DIFF
--- a/MEAL AI/Sources/Views/Camera/CameraPickerView.swift
+++ b/MEAL AI/Sources/Views/Camera/CameraPickerView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import PhotosUI
+import UIKit
+
+struct CameraPickerView: View {
+    var onImagesPicked: ([Data]) -> Void
+    var onCancel: () -> Void
+    @State private var galleryItem: PhotosPickerItem?
+
+    var body: some View {
+        ZStack {
+            CameraControllerWrapper(onImageCaptured: { image in
+                if let data = image.jpegData(compressionQuality: 0.8) {
+                    onImagesPicked([data])
+                }
+            }, onCancel: onCancel)
+            .ignoresSafeArea()
+
+            VStack {
+                Spacer()
+                HStack {
+                    PhotosPicker(selection: $galleryItem, matching: .images) {
+                        Image(systemName: "photo.on.rectangle")
+                            .font(.system(size: 28))
+                            .foregroundColor(.white)
+                            .padding(12)
+                            .background(Color.black.opacity(0.5))
+                            .clipShape(Circle())
+                    }
+                    .onChange(of: galleryItem) { item in
+                        Task { await loadFromPicker(item) }
+                    }
+                    Spacer()
+                }
+                .padding()
+            }
+        }
+    }
+
+    private func loadFromPicker(_ item: PhotosPickerItem?) async {
+        guard let item,
+              let data = try? await item.loadTransferable(type: Data.self) else { return }
+        await MainActor.run {
+            onImagesPicked([data])
+        }
+    }
+}
+
+private struct CameraControllerWrapper: UIViewControllerRepresentable {
+    var onImageCaptured: (UIImage) -> Void
+    var onCancel: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onImageCaptured: onImageCaptured, onCancel: onCancel)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) { }
+
+    final class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        var onImageCaptured: (UIImage) -> Void
+        var onCancel: () -> Void
+
+        init(onImageCaptured: @escaping (UIImage) -> Void, onCancel: @escaping () -> Void) {
+            self.onImageCaptured = onImageCaptured
+            self.onCancel = onCancel
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                onImageCaptured(image)
+            }
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            onCancel()
+        }
+    }
+}
+

--- a/MEAL AI/Sources/Views/Home/HomeView.swift
+++ b/MEAL AI/Sources/Views/Home/HomeView.swift
@@ -4,7 +4,7 @@ import UIKit
 struct HomeView: View {
     @State private var path: [Destination] = []
     @State private var query = ""
-    @State private var showImagePicker = false
+    @State private var showCamera = false
     @State private var showBarcode = false
     @State private var isLoading = false
     @State private var errorMessage: String?
@@ -34,7 +34,7 @@ struct HomeView: View {
 
                     HStack(spacing: DS.Spacing.lg.rawValue) {
                         QuickActionCard(title: "Identify", systemImage: "camera.viewfinder") {
-                            showImagePicker = true
+                            showCamera = true
                         }
                         QuickActionCard(title: "History", systemImage: "list.bullet.rectangle") {
                             path.append(.history)
@@ -58,7 +58,7 @@ struct HomeView: View {
                 TabBarWithFab(
                     onBarcode: { showBarcode = true },
                     onFavorites: { path.append(.favorites) },
-                    onCamera: { showImagePicker = true },
+                    onCamera: { showCamera = true },
                     onHistory: { path.append(.history) },
                     onSettings: { path.append(.settings) }
                 )
@@ -67,13 +67,15 @@ struct HomeView: View {
                     AnalysisOverlayView(onCancel: { isLoading = false })
                 }
             }
-            .sheet(isPresented: $showImagePicker) {
-                ImagePickerView { datas in
-                    showImagePicker = false
+            .fullScreenCover(isPresented: $showCamera) {
+                CameraPickerView(onImagesPicked: { datas in
+                    showCamera = false
                     currentImages = datas.compactMap { UIImage(data: $0) }
                     currentImage = currentImages.first
                     Task { await run(.images(datas)) }
-                }
+                }, onCancel: {
+                    showCamera = false
+                })
             }
             .sheet(isPresented: $showBarcode) {
                 BarcodeScanView { code in


### PR DESCRIPTION
## Summary
- integrate new `CameraPickerView` to capture photos and pick from the library
- update `HomeView` to present camera picker and handle gallery selections

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b3452dcffc832993e1b56bb2ce64af