### PR TITLE
Align gallery button with camera shutter

### DIFF
--- a/MEAL AI/Sources/Views/Camera/CameraPickerView.swift
+++ b/MEAL AI/Sources/Views/Camera/CameraPickerView.swift
@@ -34,6 +34,7 @@ struct CameraPickerView: View {
                 }
                 .padding()
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         }
     }
 


### PR DESCRIPTION
## Summary
- Ensure camera overlay fills the screen and positions the gallery button alongside the shutter

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b3478dd8308329b18d4de0ffae9ba9