### PR TITLE
Add custom camera controller with button layout control

### DIFF
--- a/MEAL AI/Sources/Views/Camera/CameraPickerView.swift
+++ b/MEAL AI/Sources/Views/Camera/CameraPickerView.swift
@@ -1,87 +1,15 @@
 import SwiftUI
-import PhotosUI
-import UIKit
 
 struct CameraPickerView: View {
     var onImagesPicked: ([Data]) -> Void
     var onCancel: () -> Void
-    @State private var galleryItem: PhotosPickerItem?
 
     var body: some View {
-        ZStack {
-            CameraControllerWrapper(onImageCaptured: { image in
-                if let data = image.jpegData(compressionQuality: 0.8) {
-                    onImagesPicked([data])
-                }
-            }, onCancel: onCancel)
-            .ignoresSafeArea()
-
-            VStack {
-                Spacer()
-                HStack {
-                    PhotosPicker(selection: $galleryItem, matching: .images) {
-                        Image(systemName: "photo.on.rectangle")
-                            .font(.system(size: 28))
-                            .foregroundColor(.white)
-                            .padding(12)
-                            .background(Color.black.opacity(0.5))
-                            .clipShape(Circle())
-                    }
-                    .onChange(of: galleryItem) { item in
-                        Task { await loadFromPicker(item) }
-                    }
-                    Spacer()
-                }
-                .padding()
+        CustomCameraView(onImageCaptured: { image in
+            if let data = image.jpegData(compressionQuality: 0.8) {
+                onImagesPicked([data])
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
-        }
-    }
-
-    private func loadFromPicker(_ item: PhotosPickerItem?) async {
-        guard let item,
-              let data = try? await item.loadTransferable(type: Data.self) else { return }
-        await MainActor.run {
-            onImagesPicked([data])
-        }
+        }, onCancel: onCancel)
+        .ignoresSafeArea()
     }
 }
-
-private struct CameraControllerWrapper: UIViewControllerRepresentable {
-    var onImageCaptured: (UIImage) -> Void
-    var onCancel: () -> Void
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(onImageCaptured: onImageCaptured, onCancel: onCancel)
-    }
-
-    func makeUIViewController(context: Context) -> UIImagePickerController {
-        let picker = UIImagePickerController()
-        picker.sourceType = .camera
-        picker.delegate = context.coordinator
-        return picker
-    }
-
-    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) { }
-
-    final class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
-        var onImageCaptured: (UIImage) -> Void
-        var onCancel: () -> Void
-
-        init(onImageCaptured: @escaping (UIImage) -> Void, onCancel: @escaping () -> Void) {
-            self.onImageCaptured = onImageCaptured
-            self.onCancel = onCancel
-        }
-
-        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-            if let image = info[.originalImage] as? UIImage {
-                onImageCaptured(image)
-            }
-        }
-
-        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-            onCancel()
-        }
-    }
-}
-

--- a/MEAL AI/Sources/Views/Camera/CustomCameraView.swift
+++ b/MEAL AI/Sources/Views/Camera/CustomCameraView.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+import AVFoundation
+import UIKit
+
+struct CustomCameraView: UIViewControllerRepresentable {
+    var onImageCaptured: (UIImage) -> Void
+    var onCancel: () -> Void
+
+    func makeUIViewController(context: Context) -> CameraViewController {
+        let controller = CameraViewController()
+        controller.onImageCaptured = onImageCaptured
+        controller.onCancel = onCancel
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: CameraViewController, context: Context) {}
+}
+
+final class CameraViewController: UIViewController {
+    var onImageCaptured: ((UIImage) -> Void)?
+    var onCancel: (() -> Void)?
+
+    private let session = AVCaptureSession()
+    private let photoOutput = AVCapturePhotoOutput()
+    private let previewLayer = AVCaptureVideoPreviewLayer()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupSession()
+        setupPreview()
+        setupUI()
+    }
+
+    private func setupSession() {
+        session.beginConfiguration()
+        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
+              let input = try? AVCaptureDeviceInput(device: device) else { return }
+        if session.canAddInput(input) { session.addInput(input) }
+        if session.canAddOutput(photoOutput) { session.addOutput(photoOutput) }
+        session.commitConfiguration()
+        session.startRunning()
+    }
+
+    private func setupPreview() {
+        previewLayer.session = session
+        previewLayer.videoGravity = .resizeAspectFill
+        previewLayer.frame = view.bounds
+        view.layer.addSublayer(previewLayer)
+    }
+
+    private func setupUI() {
+        let captureButton = UIButton(type: .system)
+        captureButton.translatesAutoresizingMaskIntoConstraints = false
+        captureButton.setImage(UIImage(systemName: "circle.fill"), for: .normal)
+        captureButton.tintColor = .white
+        captureButton.addTarget(self, action: #selector(capturePhoto), for: .touchUpInside)
+
+        let cancelButton = UIButton(type: .system)
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        cancelButton.setImage(UIImage(systemName: "xmark"), for: .normal)
+        cancelButton.tintColor = .white
+        cancelButton.addTarget(self, action: #selector(cancel), for: .touchUpInside)
+
+        let galleryButton = UIButton(type: .system)
+        galleryButton.translatesAutoresizingMaskIntoConstraints = false
+        galleryButton.setImage(UIImage(systemName: "photo.on.rectangle"), for: .normal)
+        galleryButton.tintColor = .white
+        galleryButton.addTarget(self, action: #selector(openGallery), for: .touchUpInside)
+
+        view.addSubview(captureButton)
+        view.addSubview(cancelButton)
+        view.addSubview(galleryButton)
+
+        NSLayoutConstraint.activate([
+            captureButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            captureButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
+
+            galleryButton.centerYAnchor.constraint(equalTo: captureButton.centerYAnchor),
+            galleryButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+
+            cancelButton.centerYAnchor.constraint(equalTo: captureButton.centerYAnchor),
+            cancelButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
+        ])
+    }
+
+    @objc private func capturePhoto() {
+        let settings = AVCapturePhotoSettings()
+        photoOutput.capturePhoto(with: settings, delegate: self)
+    }
+
+    @objc private func cancel() {
+        onCancel?()
+    }
+
+    @objc private func openGallery() {
+        let picker = UIImagePickerController()
+        picker.sourceType = .photoLibrary
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+}
+
+extension CameraViewController: AVCapturePhotoCaptureDelegate {
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        if let data = photo.fileDataRepresentation(), let image = UIImage(data: data) {
+            onImageCaptured?(image)
+        }
+    }
+}
+
+extension CameraViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let image = info[.originalImage] as? UIImage {
+            onImageCaptured?(image)
+        }
+        picker.dismiss(animated: true)
+    }
+
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true)
+    }
+}


### PR DESCRIPTION
## Summary
- Build `CustomCameraView` using `AVCaptureSession` to allow full control over capture, gallery, and cancel buttons
- Replace `CameraPickerView` to use the new controller for photo capture or gallery selection

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b3497fd23c8329a77e90ace91f1f21