### PR TITLE
Add Swift Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "MEAL_AI",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "MEAL_AI",
+            targets: ["MEAL_AI"]
+        )
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "MEAL_AI",
+            path: "MEAL AI/Sources"
+        ),
+        .testTarget(
+            name: "MEAL_AITests",
+            dependencies: ["MEAL_AI"],
+            path: "MEAL AITests"
+        ),
+        .testTarget(
+            name: "MEAL_AIUITests",
+            dependencies: ["MEAL_AI"],
+            path: "MEAL AIUITests"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- add Swift Package Manager manifest to describe app and test targets

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b34c7bc2f8832991162210093db89c