### PR TITLE
Add basic localization for Home screen

### DIFF
--- a/MEAL AI/Sources/App/MEALAIApp.swift
+++ b/MEAL AI/Sources/App/MEALAIApp.swift
@@ -3,8 +3,9 @@ import SwiftUI
 
 @main
 struct MEALAIApp: App {
+    @AppStorage("appLanguage") private var appLanguage: String = "FI"
     @State private var showShortcutAlert = false
-    @State private var shortcutMessage = ""
+    @State private var shortcutMessageKey = ""
 
     var body: some Scene {
         WindowGroup {
@@ -13,19 +14,20 @@ struct MEALAIApp: App {
                     guard url.scheme == "mealai" else { return }
                     switch url.host {
                     case "done":
-                        shortcutMessage = "Ravintoarvojen siirto onnistui"
+                        shortcutMessageKey = "app.shortcut.success"
                         showShortcutAlert = true
                     case "error":
-                        shortcutMessage = "Shortcuttin suoritus epäonnistui"
+                        shortcutMessageKey = "app.shortcut.error"
                         showShortcutAlert = true
                     default:
                         break
                     }
                 }
-                .alert(shortcutMessage, isPresented: $showShortcutAlert) {
-                    Button("OK", role: .cancel) { }
+                .alert(LocalizedStringKey(shortcutMessageKey), isPresented: $showShortcutAlert) {
+                    Button(LocalizedStringKey("app.shortcut.ok"), role: .cancel) { }
                 }
                 .environmentObject(HistoryStore.shared)
+                .environment(\.locale, Locale(identifier: appLanguage.lowercased()))
         }
     }
 }

--- a/MEAL AI/Sources/Views/Home/HomeView.swift
+++ b/MEAL AI/Sources/Views/Home/HomeView.swift
@@ -9,7 +9,7 @@ struct HomeView: View {
     @State private var showSourceOptions = false
     @State private var showBarcode = false
     @State private var isLoading = false
-    @State private var errorMessage: String?
+    @State private var errorMessageKey: String?
     @State private var result: StageMealResult?
     @State private var currentImage: UIImage?
     @State private var currentImages: [UIImage] = []
@@ -26,7 +26,7 @@ struct HomeView: View {
                 DSColor.background.ignoresSafeArea()
 
                 VStack(alignment: .leading, spacing: DS.Spacing.xl.rawValue) {
-                    Text("MEAL-AI")
+                    Text("home.title")
                         .font(DSTypography.largeTitle)
                         .foregroundStyle(DSColor.textPrimary)
 
@@ -35,19 +35,19 @@ struct HomeView: View {
                     }
 
                     HStack(spacing: DS.Spacing.lg.rawValue) {
-                        QuickActionCard(title: "Identify", systemImage: "camera.viewfinder") {
+                        QuickActionCard(titleKey: "home.action.identify", systemImage: "camera.viewfinder") {
                             showSourceOptions = true
                         }
-                        QuickActionCard(title: "History", systemImage: "list.bullet.rectangle") {
+                        QuickActionCard(titleKey: "home.action.history", systemImage: "list.bullet.rectangle") {
                             path.append(.history)
                         }
-                        QuickActionCard(title: "Favorites", systemImage: "star.fill") {
+                        QuickActionCard(titleKey: "home.action.favorites", systemImage: "star.fill") {
                             path.append(.favorites)
                         }
                     }
 
-                    if let e = errorMessage {
-                        Text(e)
+                    if let e = errorMessageKey {
+                        Text(LocalizedStringKey(e))
                             .font(DSTypography.caption)
                             .foregroundStyle(DSColor.error)
                     }
@@ -97,10 +97,10 @@ struct HomeView: View {
             .sheet(item: $result) { r in
                 ResultView(result: r, image: currentImage)
             }
-            .confirmationDialog("Select Source", isPresented: $showSourceOptions) {
-                Button("Camera") { showCamera = true }
-                Button("Photo Library") { showImagePicker = true }
-                Button("Cancel", role: .cancel) { }
+            .confirmationDialog("home.dialog.selectSource", isPresented: $showSourceOptions) {
+                Button(LocalizedStringKey("home.dialog.camera")) { showCamera = true }
+                Button(LocalizedStringKey("home.dialog.photoLibrary")) { showImagePicker = true }
+                Button(LocalizedStringKey("home.dialog.cancel"), role: .cancel) { }
             }
             .navigationDestination(for: Destination.self) { dest in
                 switch dest {
@@ -124,17 +124,17 @@ struct HomeView: View {
     @MainActor
     private func run(_ input: FoodSearchRouter.Input) async {
         guard UserDefaults.standard.foodSearchEnabled else {
-            self.errorMessage = "Food Search ei ole päällä (Asetukset → Food Search)."
+                    self.errorMessageKey = "home.error.foodSearchDisabled"
             return
         }
-        errorMessage = nil
+        errorMessageKey = nil
         isLoading = true
         defer { isLoading = false }
         do {
             let stage = try await FoodSearchRouter.shared.run(input)
             self.result = stage
         } catch {
-            self.errorMessage = error.localizedDescription
+            self.errorMessageKey = error.localizedDescription
         }
     }
 }
@@ -147,7 +147,7 @@ struct SearchBar: View {
         HStack(spacing: DS.Spacing.sm.rawValue) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(DSColor.textPrimary)
-            TextField("Search food", text: $text, onCommit: onSubmit)
+            TextField(LocalizedStringKey("home.search.placeholder"), text: $text, onCommit: onSubmit)
                 .textInputAutocapitalization(.never)
                 .disableAutocorrection(true)
                 .foregroundStyle(DSColor.textPrimary)
@@ -159,12 +159,12 @@ struct SearchBar: View {
         .overlay(
             RoundedRectangle(cornerRadius: DS.Radius.pill.rawValue).stroke(DSColor.stroke)
         )
-        .accessibilityLabel("Search food")
+        .accessibilityLabel(Text("home.search.placeholder"))
     }
 }
 
 struct QuickActionCard: View {
-    let title: String
+    let titleKey: LocalizedStringKey
     let systemImage: String
     let action: () -> Void
 
@@ -174,7 +174,7 @@ struct QuickActionCard: View {
                 Image(systemName: systemImage)
                     .font(.system(size: 24, weight: .semibold))
                     .foregroundStyle(Palette.deepForestGreen)
-                Text(title)
+                Text(titleKey)
                     .font(DSTypography.body.weight(.semibold))
                     .foregroundStyle(DSColor.textPrimary)
             }
@@ -185,7 +185,7 @@ struct QuickActionCard: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Text(title))
+        .accessibilityLabel(Text(titleKey))
     }
 }
 
@@ -201,7 +201,7 @@ struct FabButton: View {
                 .clipShape(Circle())
                 .shadow(DS.Elevation.fab)
         }
-        .accessibilityLabel("Select or capture images")
+        .accessibilityLabel(Text("home.fab.accessibility"))
     }
 }
 

--- a/MEAL AI/en.lproj/Localizable.strings
+++ b/MEAL AI/en.lproj/Localizable.strings
@@ -1,0 +1,14 @@
+"home.title" = "MEAL-AI";
+"home.action.identify" = "Identify";
+"home.action.history" = "History";
+"home.action.favorites" = "Favorites";
+"home.dialog.selectSource" = "Select Source";
+"home.dialog.camera" = "Camera";
+"home.dialog.photoLibrary" = "Photo Library";
+"home.dialog.cancel" = "Cancel";
+"home.error.foodSearchDisabled" = "Food Search is not enabled (Settings → Food Search).";
+"home.search.placeholder" = "Search food";
+"home.fab.accessibility" = "Select or capture images";
+"app.shortcut.success" = "Nutrient transfer succeeded";
+"app.shortcut.error" = "Shortcut execution failed";
+"app.shortcut.ok" = "OK";

--- a/MEAL AI/fi.lproj/Localizable.strings
+++ b/MEAL AI/fi.lproj/Localizable.strings
@@ -1,0 +1,14 @@
+"home.title" = "MEAL-AI";
+"home.action.identify" = "Tunnista";
+"home.action.history" = "Historia";
+"home.action.favorites" = "Suosikit";
+"home.dialog.selectSource" = "Valitse lähde";
+"home.dialog.camera" = "Kamera";
+"home.dialog.photoLibrary" = "Kuvakirjasto";
+"home.dialog.cancel" = "Peruuta";
+"home.error.foodSearchDisabled" = "Food Search ei ole päällä (Asetukset → Food Search).";
+"home.search.placeholder" = "Etsi ruokaa";
+"home.fab.accessibility" = "Valitse tai kuvaa kuvia";
+"app.shortcut.success" = "Ravintoarvojen siirto onnistui";
+"app.shortcut.error" = "Shortcuttin suoritus epäonnistui";
+"app.shortcut.ok" = "OK";


### PR DESCRIPTION
## Summary
- add Finnish & English Localizable.strings
- localize home screen actions and messages
- tie app language selection to SwiftUI locale

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b34e3087d88329ab31af79d9f62d3a